### PR TITLE
Add section about running script locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,26 @@ docker run --rm apk-patcher --help
 ```
 
 The patched APK is written to the same directory as `your-patched.apk`.
+
+## Using `patch-apk.sh` locally
+
+You can also run the script directly without Docker if the required
+Android tooling is installed.  The following utilities need to be
+available in your `PATH`:
+
+* `apktool`
+* `zipalign`
+* `apksigner`
+* `xmlstarlet` (optional, improves manifest editing)
+
+On most systems these can be installed via the Android SDK packages or
+your distribution's package manager.  With the tools installed, invoke
+the script just like the container image:
+
+```bash
+./patch-apk.sh myapp.apk 34 21
+```
+
+When run outside Docker the script will create a debug keystore under
+`~/.android/` if one does not already exist.  The patched APK will be
+written as `myapp-patched.apk` in the current directory.


### PR DESCRIPTION
## Summary
- document how to run `patch-apk.sh` without Docker

## Testing
- `bash -n patch-apk.sh`
- `docker build -t apk-patcher .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68480ca8889c83339fad3499ee310bcb