### PR TITLE
Add script to generate test APK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,8 @@ jobs:
           DEST=$(./create-test-data.sh)
           docker run --rm -v "$PWD/testdata:/work" apk-patcher "$(basename "$DEST")"
           docker run --rm apk-patcher --help
+      - name: Upload patched APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: patched-apk
+          path: testdata/*-patched.apk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create test data
-        run: ./create-test-data.sh
+        id: testdata
+        run: echo "dest=$(./create-test-data.sh)" >> "$GITHUB_OUTPUT"
       - name: Lint script
         run: bash -n patch-apk.sh
       - name: Build Docker image
         run: docker build -t apk-patcher .
       - name: Patch sample APK
-        run: docker run --rm -v "$PWD/testdata:/work" apk-patcher ApiDemos-debug.apk
+        run: |
+          docker run --rm -v "$PWD/testdata:/work" apk-patcher "$(basename "$DEST")"
+        env:
+          DEST: ${{ steps.testdata.outputs.dest }}
       - name: Show help
         run: docker run --rm apk-patcher --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Create test data
+        run: ./create-test-data.sh
       - name: Lint script
         run: bash -n patch-apk.sh
       - name: Build Docker image
         run: docker build -t apk-patcher .
+      - name: Patch sample APK
+        run: docker run --rm -v "$PWD/testdata:/work" apk-patcher ApiDemos-debug.apk
       - name: Show help
         run: docker run --rm apk-patcher --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Create test data
-        id: testdata
-        run: echo "dest=$(./create-test-data.sh)" >> "$GITHUB_OUTPUT"
       - name: Lint script
         run: bash -n patch-apk.sh
       - name: Build Docker image
         run: docker build -t apk-patcher .
-      - name: Patch sample APK
+      - name: Create test data and patch
         run: |
+          DEST=$(./create-test-data.sh)
           docker run --rm -v "$PWD/testdata:/work" apk-patcher "$(basename "$DEST")"
-        env:
-          DEST: ${{ steps.testdata.outputs.dest }}
-      - name: Show help
-        run: docker run --rm apk-patcher --help
+          docker run --rm apk-patcher --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated test data
+/testdata/
+# Ignore apk files
+*.apk

--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ the script just like the container image:
 When run outside Docker the script will create a debug keystore under
 `~/.android/` if one does not already exist.  The patched APK will be
 written as `myapp-patched.apk` in the current directory.
+
+## Creating test data
+
+A helper script `create-test-data.sh` is provided to download a small open
+source APK for testing. The script stores the APK under `testdata/`:
+
+```bash
+./create-test-data.sh
+```
+
+After running the script the file `testdata/ApiDemos-debug.apk` will be
+available and can be patched using the Docker image or the local script.

--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ source APK for testing. The script stores the APK under `testdata/`:
 ./create-test-data.sh
 ```
 
-After running the script the file `testdata/ApiDemos-debug.apk` will be
+After running the script the file `testdata/sample.apk` will be
 available and can be patched using the Docker image or the local script.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ the script just like the container image:
 ./patch-apk.sh myapp.apk 34 21
 ```
 
-When run outside Docker the script will create a debug keystore under
-`~/.android/` if one does not already exist.  The patched APK will be
-written as `myapp-patched.apk` in the current directory.
+When run outside Docker the script will create a temporary debug keystore
+if one does not already exist. The patched APK will be written as
+`myapp-patched.apk` in the current directory.
 
 ## Creating test data
 

--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ source APK for testing. The script stores the APK under `testdata/`:
 
 After running the script the file `testdata/sample.apk` will be
 available and can be patched using the Docker image or the local script.
+The script prints the full path to the APK on stdout so automation
+workflows can easily capture it.

--- a/create-test-data.sh
+++ b/create-test-data.sh
@@ -11,10 +11,10 @@ mkdir -p "$OUT_DIR"
 DEST="$OUT_DIR/sample.apk"
 
 if [ ! -f "$DEST" ]; then
-  echo "Downloading sample APK to $DEST..."
-  curl -L "$URL" -o "$DEST"
+  echo "Downloading sample APK to $DEST..." >&2
+  curl -L -s "$URL" -o "$DEST"
 else
-  echo "Sample APK already exists: $DEST"
+  echo "Sample APK already exists: $DEST" >&2
 fi
 
 # Print the path so callers can capture it

--- a/create-test-data.sh
+++ b/create-test-data.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Create sample data for testing patch-apk.sh
+set -euo pipefail
+
+OUT_DIR="testdata"
+URL="https://github.com/appium/sample-code/raw/master/sample-code/apps/ApiDemos-debug.apk"
+
+mkdir -p "$OUT_DIR"
+
+DEST="$OUT_DIR/ApiDemos-debug.apk"
+
+if [ ! -f "$DEST" ]; then
+  echo "Downloading sample APK..."
+  curl -L "$URL" -o "$DEST"
+else
+  echo "Sample APK already exists: $DEST"
+fi
+
+echo "Test data available at $DEST"

--- a/create-test-data.sh
+++ b/create-test-data.sh
@@ -12,7 +12,7 @@ DEST="$OUT_DIR/sample.apk"
 
 if [ ! -f "$DEST" ]; then
   echo "Downloading sample APK to $DEST..." >&2
-  curl -L -s "$URL" -o "$DEST"
+  curl -fsSL "$URL" -o "$DEST"
 else
   echo "Sample APK already exists: $DEST" >&2
 fi

--- a/create-test-data.sh
+++ b/create-test-data.sh
@@ -3,17 +3,19 @@
 set -euo pipefail
 
 OUT_DIR="testdata"
-URL="https://github.com/appium/sample-code/raw/master/sample-code/apps/ApiDemos-debug.apk"
+# Small open-source app from F-Droid
+URL="https://f-droid.org/repo/com.simplemobiletools.notes_26.apk"
 
 mkdir -p "$OUT_DIR"
 
-DEST="$OUT_DIR/ApiDemos-debug.apk"
+DEST="$OUT_DIR/sample.apk"
 
 if [ ! -f "$DEST" ]; then
-  echo "Downloading sample APK..."
+  echo "Downloading sample APK to $DEST..."
   curl -L "$URL" -o "$DEST"
 else
   echo "Sample APK already exists: $DEST"
 fi
 
-echo "Test data available at $DEST"
+# Print the path so callers can capture it
+echo "$DEST"

--- a/patch-apk.sh
+++ b/patch-apk.sh
@@ -20,7 +20,8 @@ WORKDIR="$(mktemp -d)"
 NAME="$(basename "${APK_IN%.*}")"
 OUT_DIR="$WORKDIR/out"
 PATCHED_APK="${NAME}-patched.apk"
-KEYSTORE="$HOME/.android/debug.keystore"
+# Store debug keystore in a temporary location unless overridden
+KEYSTORE="${KEYSTORE:-$WORKDIR/debug.keystore}"
 ALIAS=androiddebugkey
 STOREPASS=android
 KEYPASS=android


### PR DESCRIPTION
## Summary
- add helper script to download a sample APK for testing
- document how to create test data in README
- extend CI workflow to create sample data and run patch script

## Testing
- `bash -n patch-apk.sh`
- `docker build -t apk-patcher .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848109c932c8333ba0884a7f64b4822