### PR TITLE
Add Tkinter GUI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ When run outside Docker the script will create a temporary debug keystore
 if one does not already exist. The patched APK will be written as
 `myapp-patched.apk` in the current directory.
 
+## Using the GUI
+
+A minimal GUI is available via `patch_apk_gui.py`. Launch it with Python 3:
+
+```bash
+python3 patch_apk_gui.py
+```
+
+The interface lets you select an APK file and specify `targetSdk` and
+`minSdk` values. Behind the scenes it invokes `patch-apk.sh`, so the same
+tooling requirements apply when running outside Docker.
+
 ## Creating test data
 
 A helper script `create-test-data.sh` is provided to download a small open

--- a/patch_apk_gui.py
+++ b/patch_apk_gui.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+
+class PatchGUI(tk.Tk):
+    """Simple GUI wrapper for patch-apk.sh."""
+
+    def __init__(self):
+        super().__init__()
+        self.title("APK SDK Patcher")
+        self.resizable(False, False)
+
+        self.apk_var = tk.StringVar()
+        self.target_var = tk.StringVar(value="34")
+        self.min_var = tk.StringVar()
+
+        row = 0
+        tk.Label(self, text="APK file:").grid(row=row, column=0, sticky="e", padx=5, pady=5)
+        tk.Entry(self, textvariable=self.apk_var, width=40).grid(row=row, column=1, padx=5)
+        tk.Button(self, text="Browse", command=self.browse_apk).grid(row=row, column=2, padx=5)
+
+        row += 1
+        tk.Label(self, text="targetSdk:").grid(row=row, column=0, sticky="e", padx=5, pady=5)
+        tk.Entry(self, textvariable=self.target_var, width=10).grid(row=row, column=1, sticky="w", padx=5)
+
+        row += 1
+        tk.Label(self, text="minSdk (optional):").grid(row=row, column=0, sticky="e", padx=5, pady=5)
+        tk.Entry(self, textvariable=self.min_var, width=10).grid(row=row, column=1, sticky="w", padx=5)
+
+        row += 1
+        tk.Button(self, text="Patch APK", command=self.patch_apk).grid(row=row, column=0, columnspan=3, pady=10)
+
+    def browse_apk(self):
+        path = filedialog.askopenfilename(filetypes=[("APK files", "*.apk")])
+        if path:
+            self.apk_var.set(path)
+
+    def patch_apk(self):
+        apk = self.apk_var.get()
+        if not apk:
+            messagebox.showerror("Error", "Please select an APK file")
+            return
+
+        cmd = [os.path.join(os.path.dirname(__file__), "patch-apk.sh"), apk]
+        target = self.target_var.get().strip()
+        if target:
+            cmd.append(target)
+        min_sdk = self.min_var.get().strip()
+        if min_sdk:
+            cmd.append(min_sdk)
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            messagebox.showinfo("Success", result.stdout)
+        except subprocess.CalledProcessError as exc:
+            messagebox.showerror("Error", exc.stderr or str(exc))
+
+
+def main():
+    gui = PatchGUI()
+    gui.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `patch_apk_gui.py` with a basic Tkinter interface for `patch-apk.sh`
- document the GUI in the README

## Testing
- `bash -n patch-apk.sh`
- `docker build -t apk-patcher .` *(fails: command not found)*
- `./create-test-data.sh`
- `docker run --rm -v "$PWD/testdata:/work" apk-patcher "sample.apk"` *(fails: command not found)*
- `docker run --rm apk-patcher --help` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684835e51358833387b97fc7f7417ec6